### PR TITLE
[ADD] Support for Android Application Bundle files (aab)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The keystore properties are encrypted with AES in order to secure sensitive data
   end
 ```
 
+You can build aab files as well by providing an `aab_path` instead of an `apk_path`.
+
 ## Example
 
 Check out the [example `Fastfile`](fastlane/Fastfile) to see how to use this plugin. Try it by cloning the repo, running `fastlane install_plugins` and `bundle exec fastlane test`.


### PR DESCRIPTION
Hey Christopher,

I hope you are well.

Since August 2021 new Android apps have to be uploaded as an Android Application Bundle to the Play Store. With this PR I added the possibility to sign either APK- or AAB-Files with match_keystore. By simply adding an `aab_path` instead of an `apk_path` users can chose which one of the two should be signed.

Take care,

Simon