### PR TITLE
Remove unnecessary require which causes plugin to fail with ruby 3.x

### DIFF
--- a/lib/fastlane/plugin/match_keystore/actions/match_keystore_action.rb
+++ b/lib/fastlane/plugin/match_keystore/actions/match_keystore_action.rb
@@ -2,7 +2,6 @@ require 'fastlane/action'
 require 'fileutils'
 require 'os'
 require 'json'
-require 'pry'
 require 'digest'
 require_relative '../helper/match_keystore_helper'
 


### PR DESCRIPTION
Introduced in https://github.com/christopherney/fastlane-plugin-match_keystore/commit/82cf51f28136900a979afa2f0afe32147ce7d789

It's not actually used - the previous usage is commented out.

Causes:
```
[18:28:12]: Error loading plugin 'fastlane-plugin-match_keystore': cannot load such file -- pry
Did you mean?  pty
[18:28:12]: It seems like you wanted to load some plugins, however they couldn't be loaded
[18:28:12]: Please follow the troubleshooting guide: https://docs.fastlane.tools/plugins/plugins-troubleshooting/
+--------------------------------+---------+------------------+
|                        Used plugins                         |
+--------------------------------+---------+------------------+
| Plugin                         | Version | Action           |
+--------------------------------+---------+------------------+
| fastlane-plugin-match_keystore | 0.2.1   | No actions found |
+--------------------------------+---------+------------------+

[!] No actions were found while loading one or more plugins
    Please use `bundle exec fastlane` with plugins
    More info - https://docs.fastlane.tools/plugins/using-plugins/#run-with-plugins

Updating plugin dependencies...
Successfully updated plugins
```

On
```
➜  android git:(v1) ✗ ruby --version
ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [arm64-darwin20]
```
