### PR TITLE
Fixes openssl minimum version check

### DIFF
--- a/lib/fastlane/plugin/match_keystore/actions/match_keystore_action.rb
+++ b/lib/fastlane/plugin/match_keystore/actions/match_keystore_action.rb
@@ -106,11 +106,11 @@ module Fastlane
         UI.message("SSL/TLS protocol version: '#{vesion}'")
         if self.is_libre_ssl(forceOpenSSL)
           if Gem::Version.new(vesion) < Gem::Version.new(libressl_min)
-            raise "Minimum version for LibreSSL is '#{libressl_min}', please update it. Use homebrew is your are Mac user, and update ~/.bah_profile or ~/.zprofile"
+            raise "Minimum version for LibreSSL is '#{libressl_min}', please update it. Use homebrew is your are Mac user, and update ~/.bash_profile or ~/.zprofile"
           end
         else
-          if Gem::Version.new(vesion) > Gem::Version.new(openssl_min)
-            raise "Minimum version for OpenSSL is '#{openssl_min}' please update it. Use homebrew is your are Mac user, and update ~/.bah_profile or ~/.zprofile"
+          if Gem::Version.new(vesion) < Gem::Version.new(openssl_min)
+            raise "Minimum version for OpenSSL is '#{openssl_min}' please update it. Use homebrew is your are Mac user, and update ~/.bash_profile or ~/.zprofile"
           end
         end
 


### PR DESCRIPTION
With the current implementation, OpenSSL version check is wrong. I have OpenSSL 3.0.2 locally installed, but the logic raise an error with this message: `Minimum version for OpenSSL is '1.1.1' please update it.`